### PR TITLE
ao invés de receber um mapa com as credenciais, possui os atributos u…

### DIFF
--- a/src/main/java/br/edu/ufcg/computacao/eureca/as/api/parameters/TokenParameters.java
+++ b/src/main/java/br/edu/ufcg/computacao/eureca/as/api/parameters/TokenParameters.java
@@ -8,16 +8,40 @@ import java.util.Map;
 
 @ApiModel
 public class TokenParameters {
-    @ApiModelProperty(position = 0, required = true, example = ApiDocumentation.Model.CREDENTIALS)
-    private Map<String, String> credentials;
-    @ApiModelProperty(position = 1, required = true, example = ApiDocumentation.Model.PUBLIC_KEY)
+    //    @ApiModelProperty(position = 0, required = true, example = ApiDocumentation.Model.CREDENTIALS)
+//    private Map<String, String> credentials;
+    @ApiModelProperty(required = true)
+    private String username;
+    @ApiModelProperty(position = 1, required = true)
+    private String password;
+    @ApiModelProperty(position = 2, required = true, example = ApiDocumentation.Model.PUBLIC_KEY)
     private String publicKey;
 
     public Map<String, String> getCredentials() {
-        return credentials;
+        return Map.of("username", username, "password", password);
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 
     public String getPublicKey() {
         return publicKey;
+    }
+
+    public void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
     }
 }


### PR DESCRIPTION
O método getCredentials, que retorna um mapa de string para string (que seria o username e o password), continua existindo. Isso resolve o problema descrito na issue do alumni-backend, em que o corpo da requisição de token não é reconhecida e retorna o erro 400.